### PR TITLE
Update install url from npmjs

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
 
 
 - name: install npm
-  shell: curl https://www.npmjs.org/install.sh | bash creates=/usr/bin/npm
+  shell: curl -L https://www.npmjs.com/install.sh | bash creates=/usr/bin/npm
 
 - name: get temp directory
   command: npm -g config get tmp


### PR DESCRIPTION
The url is changed to `https://www.npmjs.com/install.sh`. I also added the `-L` so we can follow the redirect next time if they change it AGAIN... :)
