### PR TITLE
Get latest LTS from nodesource.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,33 @@
 Nodejs
-========
+======
 
-Install Nodejs and the NPM package manager
+Install Node.js and NPM
 
 Requirements
 ------------
 
-Debian Wheezy with the package python-pycurl and python-software-properties installed.
+Debian Wheezy/Jessie/Stretch or Ubuntu Precise/Trusty/Xenial.
+
+Role Variables
+--------------
+
+Specify the version of Node.js you want:
+
+    nodejs_version: 6.x
+
+See https://github.com/nodesource/distributions
 
 Example Playbook
 -------------------------
 
     - hosts: servers
       roles:
-         - { role: f500.nodejs }
+        - { role: f500.nodejs }
 
 License
 -------
 
-LGPL
+LGPL-3.0
 
 Author Information
 ------------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+
+nodejs_version: 6.x

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,17 +1,21 @@
 ---
 galaxy_info:
   author: Jasper N. Brouwer, Ramon de la Fuente
-  description: Install nodejs and npm
+  description: Install Node.js and NPM
   company: Future500
-  license: LGPL
+  license: LGPL-3.0
   min_ansible_version: 1.4
   platforms:
   - name: Debian
     versions:
       - wheezy
+      - jessie
+      - stretch
   - name: Ubuntu
     versions:
-      - all
+      - precise
+      - trusty
+      - xenial
   categories:
     - web
     - system

--- a/tasks/Debian-jessie.yml
+++ b/tasks/Debian-jessie.yml
@@ -1,4 +1,0 @@
----
-
-- name: install nodejs (Debian-jessie)
-  apt: pkg=nodejs-legacy default_release=jessie-backports state=present

--- a/tasks/Debian-wheezy.yml
+++ b/tasks/Debian-wheezy.yml
@@ -1,4 +1,0 @@
----
-
-- name: install nodejs (Debian-wheezy)
-  apt: pkg=nodejs-legacy default_release=wheezy-backports state=present

--- a/tasks/Ubuntu.yml
+++ b/tasks/Ubuntu.yml
@@ -1,4 +1,0 @@
----
-
-- name: install nodejs (Ubuntu)
-  apt: pkg=nodejs state=present

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,27 +1,35 @@
 ---
-# Install nodejs (Debian)
-- include: Debian-wheezy.yml
-  when: (ansible_distribution == "Debian" and ansible_distribution_release == "wheezy")
-- include: Debian-jessie.yml
-  when: (ansible_distribution == "Debian" and ansible_distribution_release == "jessie")
 
-# Install nodejs (Ubuntu)
-- include: Ubuntu.yml
-  when: ansible_distribution in ['Ubuntu']
+- name: Add the nodesource.com trusted key
+  apt_key:
+    id: 68576280
+    url: https://deb.nodesource.com/gpgkey/nodesource.gpg.key
 
+- name: Add the nodesource.com repository
+  apt_repository:
+    repo: "deb https://deb.nodesource.com/node_{{ nodejs_version }} {{ ansible_distribution_release }} main"
+    update_cache: no
 
-- name: install npm
-  shell: curl -L https://www.npmjs.com/install.sh | bash creates=/usr/bin/npm
+- name: Add the nodesource.com source repository
+  apt_repository:
+    repo: "deb-src https://deb.nodesource.com/node_{{ nodejs_version }} {{ ansible_distribution_release }} main"
+    update_cache: yes
 
-- name: get temp directory
+- name: Install Node.js & NPM
+  apt:
+    name: nodejs
+
+- name: Check temp directory
   command: npm -g config get tmp
   register: npm_tmp_dir
   changed_when: False
 
-- name: set temp directory
+- name: Set temp directory
   command: npm -g config set tmp /tmp
   when: npm_tmp_dir.stdout != '/tmp'
 
-- name: remove old temp directory
-  file: "path={{ npm_tmp_dir.stdout }} state=absent"
+- name: Remove old temp directory
+  file:
+    path: "{{ npm_tmp_dir.stdout }}"
+    state: absent
   when: npm_tmp_dir.stdout != '/tmp'


### PR DESCRIPTION
Use the official deb.nodesource.com repository to get Node.js (and NPM) from. Works for all versions of Debian and Ubuntu ([probably even more](https://github.com/nodesource/distributions)).

Have a variable to specify which version you want (`nodejs_version: 6.x`).

After merge I recommend tagging `v2.0.0`.